### PR TITLE
Add RouteConditionReason for no matching AllowedRoutes

### DIFF
--- a/apis/v1alpha2/shared_types.go
+++ b/apis/v1alpha2/shared_types.go
@@ -197,6 +197,10 @@ const (
 	//
 	// * "Accepted"
 	//
+	// Possible reasons for this condition to be False are:
+	//
+	// * "NotAllowedByListeners"
+	//
 	// Controllers may raise this condition with other reasons,
 	// but should prefer to use the reasons listed above to improve
 	// interoperability.
@@ -227,6 +231,11 @@ const (
 	// This reason is used with the "Accepted" condition when the Route has been
 	// accepted by the Gateway.
 	RouteReasonAccepted RouteConditionReason = "Accepted"
+
+	// This reason is used with the "Accepted" condition when the route has not
+	// been accepted by a Gateway because the Gateway had no Listener whose
+	// allowedRoutes criteria permit the route
+	RouteReasonNotAllowedByListeners RouteConditionReason = "NotAllowedByListeners"
 
 	// This reason is used with the "ResolvedRefs" condition when the condition
 	// is true.


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/kind api-change

**What this PR does / why we need it**:
Adds a RouteConditionReason for when a Gateway has no Listeners that can accept the route because none had allowedRoutes criteria that would accept it.

**Does this PR introduce a user-facing change?**:
```release-note
adds RouteReasonNotAllowedByListeners RouteConditionReason constant
```
